### PR TITLE
感情を投稿できるPOSTの保存部分を実装

### DIFF
--- a/backend/controller/FindAllRooms.go
+++ b/backend/controller/FindAllRooms.go
@@ -17,7 +17,6 @@ func NewRoom(db *sqlx.DB) *Room {
 }
 
 func (room *Room) FindAllRooms(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
-
     rooms, err := repository.AllRooms(room.db)
 
     w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/backend/controller/feeling.go
+++ b/backend/controller/feeling.go
@@ -34,8 +34,10 @@ func (feeling *Feeling) CreateFeeling(w http.ResponseWriter, r *http.Request) (i
             return err
         }
         defer func() {
-            if err := tx.Rollback(); err != nil {
-                panic(err)
+            if err := recover(); err != nil {
+                if rollbackErr := tx.Rollback(); rollbackErr != nil {
+                    panic(err)
+                }    
             }
         }()
 

--- a/backend/controller/feeling.go
+++ b/backend/controller/feeling.go
@@ -5,8 +5,6 @@ package controller
 import (
     "net/http"
     "errors"
-    "bytes"
-    "fmt"
 	"encoding/json"
 
     "github.com/jmoiron/sqlx"

--- a/backend/controller/feeling.go
+++ b/backend/controller/feeling.go
@@ -29,7 +29,10 @@ func (feeling *Feeling) CreateFeeling(w http.ResponseWriter, r *http.Request) (i
             return http.StatusBadRequest, nil, err
         }
 
-        if _, err:= repository.FindRoom(tx, feeling.RoomId); err != nil{
+        if _, err := repository.FindRoom(tx, feeling.RoomId); err != nil{
+            return http.StatusNotFound, nil, err
+        }
+        end_time, err := repository.FindRoomEndTime(tx, feeling.RoomId); err != nil {
             return http.StatusNotFound, nil, err
         }
 		if err := tx.Commit(); err != nil {

--- a/backend/controller/feeling.go
+++ b/backend/controller/feeling.go
@@ -71,7 +71,7 @@ func (feeling *Feeling) CreateFeeling(w http.ResponseWriter, r *http.Request) (i
 			return err
 		}
 		if err := tx.Commit(); err != nil {
-			return err
+			panic(err)
 		}
 		return nil
 	}(); err != nil {

--- a/backend/controller/feeling.go
+++ b/backend/controller/feeling.go
@@ -1,4 +1,5 @@
 // Written by Taishi Hosokawa
+// Feeling Controller
 package controller
 
 import (
@@ -28,6 +29,7 @@ func (feeling *Feeling) CreateFeeling(w http.ResponseWriter, r *http.Request) (i
     w.Header().Set("Access-Control-Allow-Origin", "*")
 
     var rowsAffected int64
+    // a transaction
 	if err := func() error {
         tx, err := feeling.db.Beginx()
         if err != nil {

--- a/backend/controller/feeling.go
+++ b/backend/controller/feeling.go
@@ -5,6 +5,9 @@ import (
     "net/http"
 
     "github.com/jmoiron/sqlx"
+
+    "github.com/shortintern2020-B-frontier/TeamD/repository"
+    "github.com/shortintern2020-B-frontier/TeamD/model"
 )
 
 type Feeling struct {
@@ -17,7 +20,29 @@ func NewFeeling(db *sqlx.DB) *Feeling {
 }
 
 func (feeling *Feeling) CreateFeeling(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+
+    var rowsAffected int64
+	if err := dbutil.TXHandler(a.db, func(tx *sqlx.Tx) error {
+        feeling := &model.Feeling{}
+        if err := json.NewDecoder(r.Body).Decode(&feeling); err != nil {
+            return http.StatusBadRequest, nil, err
+        }
+
+        if _, err:= repository.FindRoom(tx, feeling.RoomId); err != nil{
+            return http.StatusNotFound, nil, err
+        }
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		rowsAffected, err = result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return 0, err
+	}
 	return http.StatusOK, nil, nil
 }
 

--- a/backend/model/feeling.go
+++ b/backend/model/feeling.go
@@ -2,6 +2,6 @@ package model
 
 type Feeling struct {
     StampId int `db:"stamp_id" json:"stamp_id"`
-    RoomId string `db:"room_id" json:"room_id"`
-    ellapsed_time int `db:"ellapsed_time" json:"ptime"`
+    RoomId int `db:"room_id" json:"room_id"`
+    EllapsedTime int `db:"ellapsed_time" json:"ptime"`
 }

--- a/backend/model/feeling.go
+++ b/backend/model/feeling.go
@@ -1,0 +1,7 @@
+package model
+
+type Feeling struct {
+    StampId int `db:"stamp_id" json:"stamp_id"`
+    RoomId string `db:"room_id" json:"room_id"`
+    ellapsed_time int `db:"ellapsed_time" json:"ptime"`
+}

--- a/backend/repository/feeling.go
+++ b/backend/repository/feeling.go
@@ -1,3 +1,4 @@
+// Written by Taishi Hosokawa
 package repository
 
 import (

--- a/backend/repository/feeling.go
+++ b/backend/repository/feeling.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+    "github.com/jmoiron/sqlx"
+
+)
+
+func CreateFeeling (db *sqlx.Tx, room_id int, stamp_id int, ellapsed_time int) (result sql.Result, err error){
+	stmt, err := db.Prepare(`
+	INSERT INTO feeling (room_id, stamp_id, ellapsed_time) VAUES(?, ?, ?)
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			err = closeErr
+		}
+	}()
+	return stmt.Exec(room_id, stamp_id, ellapsed_time)
+}

--- a/backend/repository/feeling.go
+++ b/backend/repository/feeling.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shortintern2020-B-frontier/TeamD/model"
 )
 
+// inserts feeling record
 func CreateFeeling (db *sqlx.Tx, feeling *model.Feeling) (result sql.Result, err error){
 	stmt, err := db.Prepare(`
 	INSERT INTO feeling (room_id, stamp_id, ellapsed_time) VALUES(?, ?, ?)

--- a/backend/repository/feeling.go
+++ b/backend/repository/feeling.go
@@ -2,13 +2,16 @@
 package repository
 
 import (
-    "github.com/jmoiron/sqlx"
+	"database/sql"
 
+	"github.com/jmoiron/sqlx"
+	
+	"github.com/shortintern2020-B-frontier/TeamD/model"
 )
 
-func CreateFeeling (db *sqlx.Tx, room_id int, stamp_id int, ellapsed_time int) (result sql.Result, err error){
+func CreateFeeling (db *sqlx.Tx, feeling *model.Feeling) (result sql.Result, err error){
 	stmt, err := db.Prepare(`
-	INSERT INTO feeling (room_id, stamp_id, ellapsed_time) VAUES(?, ?, ?)
+	INSERT INTO feeling (room_id, stamp_id, ellapsed_time) VALUES(?, ?, ?)
 	`)
 	if err != nil {
 		return nil, err
@@ -18,5 +21,5 @@ func CreateFeeling (db *sqlx.Tx, room_id int, stamp_id int, ellapsed_time int) (
 			err = closeErr
 		}
 	}()
-	return stmt.Exec(room_id, stamp_id, ellapsed_time)
+	return stmt.Exec(feeling.RoomId, feeling.StampId, feeling.EllapsedTime)
 }

--- a/backend/repository/room.go
+++ b/backend/repository/room.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+    "errors"
+
     "github.com/jmoiron/sqlx"
 
     "github.com/shortintern2020-B-frontier/TeamD/model"
@@ -15,4 +17,30 @@ func AllRooms(db *sqlx.DB) ([]model.Room, error) {
     }
 
     return rooms, nil
+}
+
+//Written by Taishi Hosokawa
+func FindRoom(db *sqlx.Tx, id int) (*int, error) {
+    var a *int
+    if err := db.Get(a, `
+    SELECT id FROM room WHERE id = ?
+    `, id); err != nil {
+        return nil, err
+    }
+    if a == nil {
+        return nil, errors.New("specified room does not exist")
+    }
+    return a, nil
+}
+
+// Written by Taishi Hosokawa
+func GetRoomEndTime(db *sqlx.Tx, id int) (*int, error) {
+    var endtime *int 
+    if err := db.Get(endtime,`
+    SELECT end_time FROM room WHERE id = ?
+    `, id); err != nil {
+        return nil, errors.New("specified room does not exist")
+    }
+
+    return endtime, nil
 }

--- a/backend/repository/room.go
+++ b/backend/repository/room.go
@@ -21,26 +21,26 @@ func AllRooms(db *sqlx.DB) ([]model.Room, error) {
 
 //Written by Taishi Hosokawa
 func FindRoom(db *sqlx.Tx, id int) (*int, error) {
-    var a *int
-    if err := db.Get(a, `
+    var a int
+    if err := db.Get(&a, `
     SELECT id FROM room WHERE id = ?
     `, id); err != nil {
         return nil, err
     }
-    if a == nil {
+    if a == 0 {
         return nil, errors.New("specified room does not exist")
     }
-    return a, nil
+    return &a, nil
 }
 
 // Written by Taishi Hosokawa
 func FindRoomEndTime(db *sqlx.Tx, id int) (*int, error) {
-    var endtime *int 
-    if err := db.Get(endtime,`
+    var endtime int 
+    if err := db.Get(&endtime,`
     SELECT end_time FROM room WHERE id = ?
     `, id); err != nil {
         return nil, errors.New("specified room does not exist")
     }
 
-    return endtime, nil
+    return &endtime, nil
 }

--- a/backend/repository/room.go
+++ b/backend/repository/room.go
@@ -20,6 +20,7 @@ func AllRooms(db *sqlx.DB) ([]model.Room, error) {
 }
 
 //Written by Taishi Hosokawa
+// returns the id of a room to check the existence
 func FindRoom(db *sqlx.Tx, id int) (*int, error) {
     var a int
     if err := db.Get(&a, `
@@ -34,6 +35,7 @@ func FindRoom(db *sqlx.Tx, id int) (*int, error) {
 }
 
 // Written by Taishi Hosokawa
+// returns the end_time of room
 func FindRoomEndTime(db *sqlx.Tx, id int) (*int, error) {
     var endtime int 
     if err := db.Get(&endtime,`

--- a/backend/repository/room.go
+++ b/backend/repository/room.go
@@ -34,7 +34,7 @@ func FindRoom(db *sqlx.Tx, id int) (*int, error) {
 }
 
 // Written by Taishi Hosokawa
-func GetRoomEndTime(db *sqlx.Tx, id int) (*int, error) {
+func FindRoomEndTime(db *sqlx.Tx, id int) (*int, error) {
     var endtime *int 
     if err := db.Get(endtime,`
     SELECT end_time FROM room WHERE id = ?

--- a/backend/repository/stamp.go
+++ b/backend/repository/stamp.go
@@ -1,0 +1,20 @@
+// Written by Taishi Hosokawa
+package repository
+
+import (
+	"errors"
+	"github.com/jmoiron/sqlx"
+)
+
+func FindStamp (db *sqlx.Tx, id int) (*int, error){
+	var a *int
+	if err := db.Get(a, `
+	SELECT id FROM stamp WHERE id = ?
+	`, id); err != nil {
+		return nil, err
+	}
+	if a == nil {
+		return nil, errors.New("specified id")
+	}
+	return a, nil
+}

--- a/backend/repository/stamp.go
+++ b/backend/repository/stamp.go
@@ -9,17 +9,19 @@ import (
     "github.com/shortintern2020-B-frontier/TeamD/model"
 )
 
+// Written by Taishi Hosokawa
+// Find a stamp that has gien id
 func FindStamp (db *sqlx.Tx, id int) (*int, error){
-	var a *int
-	if err := db.Get(a, `
+	var a int
+	if err := db.Get(&a, `
 	SELECT id FROM stamp WHERE id = ?
 	`, id); err != nil {
 		return nil, err
 	}
-	if a == nil {
+	if a == 0 {
 		return nil, errors.New("specified id")
 	}
-	return a, nil
+	return &a, nil
 }
 
 // データベースから


### PR DESCRIPTION
感情を投稿するエンドポイント　#13
の実際に中身を保存する部分を実装しました

ルームの存在、スタンプの存在、エンドタイムとの整合性を試してから挿入処理をするようにしています。

```
curl --request POST --header "Content-Type: application/json" --data "{\"stamp_id\":1,\"room_id\":1, \"ptime\":5000}" "http://localhost:1996/api/room/1/feeling"
```

```
mysql> select * from feeling
    -> ;
+----------+---------+---------------+---------------------+
| stamp_id | room_id | ellapsed_time | ctime               |
+----------+---------+---------------+---------------------+
|        1 |       1 |             3 | 2020-09-06 01:15:31 |
|        2 |       1 |             6 | 2020-09-06 01:15:31 |
|        3 |       2 |            20 | 2020-09-06 01:15:31 |
|        1 |       1 |          5000 | 2020-09-06 15:23:39 |
+----------+---------+---------------+---------------------+
```
のようになるはずです。エラー周り等を特に見てほしいです