### PR TITLE
各時間における視聴者数のスキーマの追加

### DIFF
--- a/database/migration/schema/V5__create_table_audience.sql
+++ b/database/migration/schema/V5__create_table_audience.sql
@@ -1,0 +1,10 @@
+CREATE TABLE audience (
+  room_id INT UNSIGNED,
+  ellapsed_time INT NOT NULL,
+  count INT NOT NULL default 0,
+  FOREIGN KEY (room_id) REFERENCES room(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT audience (room_id, ellapsed_time, count) VALUES (1, 0, 3);
+INSERT audience (room_id, ellapsed_time, count) VALUES (1, 60000, 6);
+INSERT audience (room_id, ellapsed_time, count) VALUES (2, 0, 20);


### PR DESCRIPTION
各時間における視聴者数のスキーマ audienceの追加をしました
migrateした上で、
```
mysql> select * from audience;
+---------+---------------+-------+
| room_id | ellapsed_time | count |
+---------+---------------+-------+
|       1 |             0 |     3 |
|       1 |         60000 |     6 |
|       2 |             0 |    20 |
+---------+---------------+-------+
```

```
Schema version: 5

+-----------+---------+-----------------------+------+---------------------+---------+
| Category  | Version | Description           | Type | Installed On        | State   |
+-----------+---------+-----------------------+------+---------------------+---------+
| Versioned | 1       | baseline              | SQL  | 2020-09-06 01:11:25 | Success |
| Versioned | 2       | create table room     | SQL  | 2020-09-06 01:11:25 | Success |
| Versioned | 3       | create table stamp    | SQL  | 2020-09-06 01:11:25 | Success |
| Versioned | 4       | create table feeling  | SQL  | 2020-09-06 01:15:31 | Success |
| Versioned | 5       | create table audience | SQL  | 2020-09-06 23:09:56 | Success |
+-----------+---------+-----------------------+------+---------------------+---------+
```