### PR TITLE
参加者数のGETエンドポイントを作成しました

### DIFF
--- a/backend/controller/audience.go
+++ b/backend/controller/audience.go
@@ -1,3 +1,4 @@
+// audience controller
 package controller
 
 import (
@@ -14,11 +15,14 @@ type Audience struct {
 	db *sqlx.DB
 }
 
+//constructor
 func NewAudience(db *sqlx.DB) *Audience {
 	return &Audience{db: db}
 }
 
+//return audience.count from audience table
 func (audience *Audience) FindAudience(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
+	// get parameters from url
 	ellapsed_time, _ := strconv.Atoi(r.FormValue("ellapsed_time"))
     vars := mux.Vars(r)
 	room_id, err := strconv.Atoi(vars["room_id"])
@@ -26,10 +30,12 @@ func (audience *Audience) FindAudience(w http.ResponseWriter, r *http.Request) (
 		return http.StatusBadRequest, nil, err
 	}
 
+	//check if room exists
 	if _, err := repository.FindRoomDB(audience.db, room_id); err != nil {
 		return http.StatusNotFound, nil, err
 	}
 
+	//retrieve audience.count from database
 	a, err := repository.FindAudience(audience.db, room_id, ellapsed_time)
 	if err != nil {
 		return http.StatusInternalServerError, nil, err

--- a/backend/controller/audience.go
+++ b/backend/controller/audience.go
@@ -1,0 +1,21 @@
+package controller
+
+import (
+    "net/http"
+    "github.com/jmoiron/sqlx"
+
+//    "github.com/shortintern2020-B-frontier/TeamD/repository"
+//    "github.com/shortintern2020-B-frontier/TeamD/model"
+)
+
+type Audience struct {
+	db *sqlx.DB
+}
+
+func NewAudience(db *sqlx.DB) *Audience {
+	return &Audience{db: db}
+}
+
+func (audience *Audience) FindAudience(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
+	return http.StatusOK, nil, nil
+}

--- a/backend/controller/audience.go
+++ b/backend/controller/audience.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
-    "net/http"
-    "github.com/jmoiron/sqlx"
+	"net/http"
+	"strconv"
 
-//    "github.com/shortintern2020-B-frontier/TeamD/repository"
-//    "github.com/shortintern2020-B-frontier/TeamD/model"
+	"github.com/jmoiron/sqlx"
+	"github.com/gorilla/mux"
+
+    "github.com/shortintern2020-B-frontier/TeamD/repository"
 )
 
 type Audience struct {
@@ -17,5 +19,21 @@ func NewAudience(db *sqlx.DB) *Audience {
 }
 
 func (audience *Audience) FindAudience(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
-	return http.StatusOK, nil, nil
+	ellapsed_time, _ := strconv.Atoi(r.FormValue("ellapsed_time"))
+    vars := mux.Vars(r)
+	room_id, err := strconv.Atoi(vars["room_id"])
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	if _, err := repository.FindRoomDB(audience.db, room_id); err != nil {
+		return http.StatusNotFound, nil, err
+	}
+
+	a, err := repository.FindAudience(audience.db, room_id, ellapsed_time)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	return http.StatusOK, a, nil
 }

--- a/backend/model/audience.go
+++ b/backend/model/audience.go
@@ -1,0 +1,5 @@
+package model
+
+type Audience struct {
+    Audience int `db:"count" json:"audience"`
+}

--- a/backend/model/audience.go
+++ b/backend/model/audience.go
@@ -1,3 +1,4 @@
+// audience model
 package model
 
 type Audience struct {

--- a/backend/repository/audience.go
+++ b/backend/repository/audience.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"github.com/jmoiron/sqlx"
+)
+
+func FindAudience (db *sqlx.DB, id, ellapsed_time int) (*int, error) {
+	var audience int
+	if err := db.Get(&audience, `
+	SELECT count FROM audience WHERE room_id = ? AND ellapsed_time = ?
+	`, id, ellapsed_time); err != nil {
+		return nil, err
+	}
+	return &audience, nil
+}

--- a/backend/repository/audience.go
+++ b/backend/repository/audience.go
@@ -4,6 +4,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// return audience.count
 func FindAudience (db *sqlx.DB, id, ellapsed_time int) (*int, error) {
 	var audience int
 	if err := db.Get(&audience, `

--- a/backend/repository/audience.go
+++ b/backend/repository/audience.go
@@ -2,11 +2,13 @@ package repository
 
 import (
 	"github.com/jmoiron/sqlx"
+
+	"github.com/shortintern2020-B-frontier/TeamD/model"
 )
 
 // return audience.count
-func FindAudience (db *sqlx.DB, id, ellapsed_time int) (*int, error) {
-	var audience int
+func FindAudience (db *sqlx.DB, id, ellapsed_time int) (*model.Audience, error) {
+	var audience model.Audience
 	if err := db.Get(&audience, `
 	SELECT count FROM audience WHERE room_id = ? AND ellapsed_time = ?
 	`, id, ellapsed_time); err != nil {

--- a/backend/repository/room.go
+++ b/backend/repository/room.go
@@ -45,3 +45,16 @@ func FindRoomEndTime(db *sqlx.Tx, id int) (*int, error) {
 
     return &endtime, nil
 }
+
+func FindRoomDB(db *sqlx.DB, id int) (*int, error) {
+    var a int
+    if err := db.Get(&a, `
+    SELECT id FROM room WHERE id = ?
+    `, id); err != nil {
+        return nil, err
+    }
+    if a == 0 {
+        return nil, errors.New("specified room does not exist")
+    }
+    return &a, nil
+}

--- a/backend/repository/room.go
+++ b/backend/repository/room.go
@@ -58,3 +58,14 @@ func FindRoomDB(db *sqlx.DB, id int) (*int, error) {
     }
     return &a, nil
 }
+
+func FindRoomEndTimeDB(db *sqlx.DB, id int) (*int, error) {
+    var endtime int 
+    if err := db.Get(&endtime,`
+    SELECT end_time FROM room WHERE id = ?
+    `, id); err != nil {
+        return nil, errors.New("specified room does not exist")
+    }
+
+    return &endtime, nil
+}

--- a/backend/sever.go
+++ b/backend/sever.go
@@ -68,7 +68,10 @@ func (s *Server) Route() *mux.Router {
 	r.Methods(http.MethodPost).Path("/api/room/{id:[0-9]+}/feeling").Handler(AppHandler{feelingController.CreateFeeling})
 
 	stamp_controller := controller.NewStamp(s.db)
-    r.Methods(http.MethodGet).Path("/api/room/{room_id}/feeling").Queries("ellapsed_time", "{[0-9]+?}").Handler(AppHandler{stamp_controller.FindStamps})
+	r.Methods(http.MethodGet).Path("/api/room/{room_id}/feeling").Queries("ellapsed_time", "{[0-9]+?}").Handler(AppHandler{stamp_controller.FindStamps})
+	
+	audienceController := controller.NewAudience(s.db)
+	r.Methods(http.MethodGet).Path("/api/room/{room_id}/audience").Queries("ellapsed_time", "{[0-9]+?}").Handler(AppHandler{audienceController.FindAudience})
 
 	return r
 


### PR DESCRIPTION
/api/room/<id>/audienceにエンドポイントを作成しました
api設計のところにもあるように
・部屋のIDが数字列でなかったり、パラメータで渡しているellapsed_timeが数字列でなかったら400
・部屋が存在していなかったら404
・エンドタイムをellapsed_timeが超えていれば404
・テーブル中に対応するellapsed_timeが存在しなければ500
が返るようになっているはずです

例
```
curl -v -H http://localhost:3000 http://localhost:1996/api/room/1/audience?ellapsed_time=60000
```
```
< HTTP/1.1 200 OK
{
    "audience": 6
}
```