### PR TITLE
CORSを暫定的に処理

### DIFF
--- a/backend/sever.go
+++ b/backend/sever.go
@@ -48,10 +48,18 @@ func (s *Server) Run(port int) {
 
 func (s *Server) Route() *mux.Router {
 	r := mux.NewRouter()
+
 	r.Methods(http.MethodGet).Path("/ping").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("pong"))
+	})
+
+	r.Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, access-control-allow-origin")
+		w.WriteHeader(http.StatusOK)
 	})
 	
 	r.Methods(http.MethodOptions).Path("/api/room/{room_id}/feeling").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
元々各エンドポイントではすべてのoriginを受け入れているのですが、OPTIONSメソッドで来たものはすべて受け入れるようにしました
よくはない仕様なので暫定的としたいです