### PR TITLE
視聴者数のレコードを追加するストアドプロシージャと視聴者数テーブルの変更

### DIFF
--- a/database/migration/schema/V6__alter_table_audience.sql
+++ b/database/migration/schema/V6__alter_table_audience.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audience ADD PRIMARY KEY (ellapsed_time, room_id);

--- a/database/migration/schema/V6__create_procedure_insert_audience.sql
+++ b/database/migration/schema/V6__create_procedure_insert_audience.sql
@@ -1,0 +1,23 @@
+DROP PROCEDURE IF EXISTS insert_audience;
+DELIMITER //
+CREATE PROCEDURE insert_audience(IN room_id INT, IN start_time INT)
+
+BEGIN
+  DECLARE end_time INT DEFAULT 0;
+  DECLARE end_times CURSOR FOR
+    SELECT end_time FROM room WHERE id = room_id;
+  OPEN end_times;
+  FETCH end_times INTO end_time;
+  CLOSE end_times;
+
+  DECLARE i INT DEFAULT start_time / 60000;
+  WHILE i <= end_time / 60000 DO
+  INSERT INTO audience (room_id, ellapsed_time, count) VALUES (room_id, i*60000, 0);
+  END WHILE;
+END
+//
+DELIMITER ;
+
+
+call insert_audience(1, 120000);
+call insert_audience(2, 60000);

--- a/database/migration/schema/V6__create_procedure_insert_audience.sql
+++ b/database/migration/schema/V6__create_procedure_insert_audience.sql
@@ -1,6 +1,7 @@
 DROP PROCEDURE IF EXISTS insert_audience;
 DELIMITER //
 CREATE PROCEDURE insert_audience(IN room_id INT, IN start_time INT)
+DECLARE e INT DEFAULT 0;
 
 BEGIN
   DECLARE end_time INT DEFAULT 0;
@@ -10,12 +11,11 @@ BEGIN
   FETCH end_times INTO end_time;
   CLOSE end_times;
 
-  DECLARE i INT DEFAULT start_time / 60000;
-  WHILE i <= end_time / 60000 DO
-  INSERT INTO audience (room_id, ellapsed_time, count) VALUES (room_id, i*60000, 0);
+  DECLARE i INT DEFAULT start_time DIV 60000;
+  WHILE i < (end_time DIV 60000)+1 DO
+    INSERT audience (room_id, ellapsed_time, count) VALUES(room_id, i*60000, 0);
   END WHILE;
-END
-//
+END//
 DELIMITER ;
 
 

--- a/database/migration/schema/V7__create_procedure_insert_audience.sql
+++ b/database/migration/schema/V7__create_procedure_insert_audience.sql
@@ -8,10 +8,10 @@ BEGIN
   DECLARE end_time INT DEFAULT 0;
   DECLARE cursor_end_time CURSOR FOR
     SELECT roomA.end_time FROM room AS roomA WHERE id = room_id;
-  OPEN cursor_end_times;
-  FETCH cursor_end_times INTO end_time;
-  CLOSE cursor_end_times;
-  
+  OPEN cursor_end_time;
+  FETCH cursor_end_time INTO end_time;
+  CLOSE cursor_end_time;
+
   WHILE target_ellapsed_time <= end_time DO
     INSERT audience (room_id, ellapsed_time, count) VALUES(room_id, target_ellapsed_time, 0);
     set target_ellapsed_time = target_ellapsed_time + 60000;

--- a/database/migration/schema/V7__create_procedure_insert_audience.sql
+++ b/database/migration/schema/V7__create_procedure_insert_audience.sql
@@ -1,20 +1,20 @@
 DROP PROCEDURE IF EXISTS insert_audience;
 DELIMITER //
 CREATE PROCEDURE insert_audience(IN room_id INT, IN start_time INT)
-DECLARE e INT DEFAULT 0;
 
 BEGIN
+  DECLARE i INT DEFAULT start_time DIV 60000;
   DECLARE end_time INT DEFAULT 0;
   DECLARE end_times CURSOR FOR
-    SELECT end_time FROM room WHERE id = room_id;
+    SELECT roomA.end_time FROM room AS roomA WHERE id = room_id;
   OPEN end_times;
   FETCH end_times INTO end_time;
   CLOSE end_times;
-
-  DECLARE i INT DEFAULT start_time DIV 60000;
   WHILE i < (end_time DIV 60000)+1 DO
     INSERT audience (room_id, ellapsed_time, count) VALUES(room_id, i*60000, 0);
+    set i=i+1;
   END WHILE;
+COMMIT;
 END//
 DELIMITER ;
 

--- a/database/migration/schema/V7__create_procedure_insert_audience.sql
+++ b/database/migration/schema/V7__create_procedure_insert_audience.sql
@@ -1,18 +1,20 @@
+# Written by Taishi Hosokawa
 DROP PROCEDURE IF EXISTS insert_audience;
 DELIMITER //
 CREATE PROCEDURE insert_audience(IN room_id INT, IN start_time INT)
 
 BEGIN
-  DECLARE i INT DEFAULT start_time DIV 60000;
+  DECLARE target_ellapsed_time INT DEFAULT start_time;
   DECLARE end_time INT DEFAULT 0;
-  DECLARE end_times CURSOR FOR
+  DECLARE cursor_end_time CURSOR FOR
     SELECT roomA.end_time FROM room AS roomA WHERE id = room_id;
-  OPEN end_times;
-  FETCH end_times INTO end_time;
-  CLOSE end_times;
-  WHILE i < (end_time DIV 60000)+1 DO
-    INSERT audience (room_id, ellapsed_time, count) VALUES(room_id, i*60000, 0);
-    set i=i+1;
+  OPEN cursor_end_times;
+  FETCH cursor_end_times INTO end_time;
+  CLOSE cursor_end_times;
+  
+  WHILE target_ellapsed_time <= end_time DO
+    INSERT audience (room_id, ellapsed_time, count) VALUES(room_id, target_ellapsed_time, 0);
+    set target_ellapsed_time = target_ellapsed_time + 60000;
   END WHILE;
 COMMIT;
 END//


### PR DESCRIPTION
主キーをellapse_timeとroom_idに設定しました
また、ストアドプロシージャでレコードを繰り返し追加することができるようになりました

```
mysql> select * from audience where room_id = 1;
+---------+---------------+-------+
| room_id | ellapsed_time | count |
+---------+---------------+-------+
|       1 |             0 |     3 |
|       1 |         60000 |     6 |
|       1 |        120000 |     0 |
|       1 |        180000 |     0 |
|       1 |        240000 |     0 |
|       1 |        300000 |     0 |
|       1 |        360000 |     0 |
|       1 |        420000 |     0 |
|       1 |        480000 |     0 |
|       1 |        540000 |     0 |
|       1 |        600000 |     0 |
|       1 |        660000 |     0 |
|       1 |        720000 |     0 |
|       1 |        780000 |     0 |
|       1 |        840000 |     0 |
|       1 |        900000 |     0 |
|       1 |        960000 |     0 |
|       1 |       1020000 |     0 |
|       1 |       1080000 |     0 |
|       1 |       1140000 |     0
```