### PR TITLE
プレゼン用ルーム作成

### DIFF
--- a/database/migration/schema/V8__insert_record_room.sql
+++ b/database/migration/schema/V8__insert_record_room.sql
@@ -1,0 +1,4 @@
+# Written by Taishi Hosokawa
+
+INSERT room (id, title, image_url, end_time) VALUES (NULL, "ふゆのエビアボカド", "https://i.pinimg.com/originals/e7/83/20/e78320b750eb618a6da0342208fb09a7.png", 9000000);
+call insert_audience(3, 0);


### PR DESCRIPTION
プレゼン用のルームデータを作成しました
画像は
"https://i.pinimg.com/originals/e7/83/20/e78320b750eb618a6da0342208fb09a7.png"
より。
migrateすると自分のターミナルがutf-8でなくて文字化けしていますが、
```
mysql> select * from room
    -> ;
+----+----------------+--------------------------------------------------------------------------------------+----------+---------------------+
| id | title          | image_url                                                                            | end_time | ctime               |
+----+----------------+--------------------------------------------------------------------------------------+----------+---------------------+
|  1 | FIFA World Cup | https://pictkan.com/uploads/cache/1126823654/football-689262_1920-400x270-MM-100.jpg |  7200000 | 2020-09-07 17:19:01 |
|  2 | ??vs??         | https://pictkan.com/uploads/cache/2993133857/baseball-636802-225x150-MM-100.jpg      |  9000000 | 2020-09-07 17:19:01 |
|  3 | ?????????      | https://i.pinimg.com/originals/e7/83/20/e78320b750eb618a6da0342208fb09a7.png         |  9000000 | 2020-09-08 01:58:39 |
+----+----------------+--------------------------------------------------------------------------------------+----------+---------------------+
```

```
select * from audience where room_id = 3
    -> ;
+---------+---------------+-------+
| room_id | ellapsed_time | count |
+---------+---------------+-------+
|       3 |             0 |     0 |
|       3 |         60000 |     0 |
|       3 |        120000 |     0 |
|       3 |        180000 |     0 |
|       3 |        240000 |     0 |
|       3 |        300000 |     0 |
|       3 |        360000 |     0 |
|       3 |        420000 |     0 |
|       3 |        480000 |     0 |
|       3 |        540000 |     0 |
```
のようになるはずです